### PR TITLE
Improve docs for Sun, SGI, and composite sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,30 +17,31 @@ Unless you need the composite sync separator, assembly is easy: just install J1 
 
 You will need to solder some jumper wires to configure the 13W3 adapter for the particular workstation you are using. Ground pads are located next to the pads that are marked with the pin number that they are connected to. Using the table below, connect the pads to ground, leave them floating, or jumper them to the H (horizontal sync) or V (vertical sync) pads.
 
-| 13W3 pin | Sun (old)          | Sun (DDC)        | RS/6000 [4]     | SGI [5]     |
-|----------|--------------------|------------------|-----------------|-------------|
-| 1        | n/c (serial read)  | n/c (DDC SCL)    | Gnd (ID-2)      | n/c (mon3)  |
-| 2        | n/c (Vsync) [1]    | n/c (DDC 5V)     | n/c (ID-3)      | n/c (mon2)  |
-| 3        | n/c (sense2) [3]   | n/c (sense2) [3] | Gnd (self test) | n/c (Csync) |
-| 4        | Gnd (for sense)    | Gnd (for DDC)    | Gnd             | H           |
-| 5        | H (Csync) [1]      | H (Csync) [2]    | H               | V           |
-| 6        | n/c (Hsync) [1]    | n/c (DDC SDA)    | Gnd (ID-0)      | n/c (mon1)  |
-| 7        | n/c (serial write) | n/c (Vsync) [2]  | n/c (ID-1)      | n/c (mon2)  |
-| 8        | n/c (sense1) [3]   | n/c (sense1) [3] | n/c             | Gnd         |
-| 9        | n/c (sense0) [3]   | n/c (sense0) [3] | V               | Gnd         |
-| 10       | Gnd (for sync)     | Gnd (for sync)   | Gnd             | Gnd         |
+| 13W3 pin | Sun (old)          | Sun (DDC)        | RS/6000 [1]     | SGI (old) [2]    | SGI (DDC) [2]   |
+|----------|--------------------|------------------|-----------------|------------------|-----------------|
+| 1        | n/c (serial read)  | n/c (DDC SCL)    | Gnd (ID-2)      | n/c (id3)        | n/c (DDC SCL)   |
+| 2        | n/c (Vsync) [3]    | n/c (DDC 5V in)  | n/c (ID-3)      | n/c (id0)        | n/c (DDC SDA)   |
+| 3        | n/c (sense2) [6]   | n/c (sense2) [6] | Gnd (self test) | n/c (Csync)  [5] | n/c (Csync)     |
+| 4        | Gnd (for sense)    | Gnd (for DDC)    | Gnd             | n/c (Hdrive) [5] | H               |
+| 5        | H (Csync) [3]      | H (Csync) [4]    | H               | n/c (Vdrive) [5] | V               |
+| 6        | n/c (Hsync) [3]    | n/c (DDC SDA)    | Gnd (ID-0)      | n/c (id1)        | n/c (DDC 5V in) |
+| 7        | n/c (serial write) | n/c (Vsync) [4]  | n/c (ID-1)      | n/c (id2)        | Gnd (for DDC)   |
+| 8        | n/c (sense1) [6]   | n/c (sense1) [6] | n/c             | Gnd              | Gnd             |
+| 9        | n/c (sense0) [6]   | n/c (sense0) [6] | V               | Gnd              | Gnd             |
+| 10       | Gnd (for sync)     | Gnd (for sync)   | Gnd             | Gnd              | Gnd             |
 
 Notes:
-1. Some video cards with Sun's old pinout lack Hsync and Vsync, so we connect Csync to the H pad (but see § Composite Sync).
-2. All video cards with Sun's DDC pinout lack Hsync, so we connect Csync to the H pad (but see § Composite Sync).
-3. Sense codes control the default resolution and refresh rate, unless DDC is supported and connected to your VGA monitor.
+1. The RS/6000 is wired for monitor ID 1010.
+2. The SGI wiring connections have not been tested but should work.
+3. Some video cards with Sun's old pinout lack Hsync and Vsync, so we connect Csync to the H pad (but see § Composite Sync).
+4. All video cards with Sun's DDC pinout lack Hsync, so we connect Csync to the H pad (but see § Composite Sync).
+5. Hdrive and Vdrive are not equivalent to Hsync and Vsync, so we connect Csync to the H pad (but see § Composite Sync).
+6. Sense codes control the default resolution and refresh rate, unless DDC is supported and connected to your VGA monitor.
     * default sense code 000<sub>2</sub> is 1152x900@66
     * jump pins 3 and 9 to Gnd (101<sub>2</sub>) for 1280x1024@76
     * jump pin 8 to Gnd (010<sub>2</sub>) for 1024x768@60
     * for other sense codes, see [TurboGX/TurboGXplus Hardware Installation Guide](https://docs.oracle.com/cd/E19957-01/801-5399-10/801-5399-10.pdf), Table C-3
     * not all sense codes are supported by all video cards, see the Sun [Frame Buffer FAQ](http://www.sunhelp.org/faq/FrameBuffer.html#5)
-4. The RS/6000 is wired for monitor ID 1010.
-5. The SGI wiring connections have not been tested but should work.
 
 Once you finish the wiring, it's a good idea to mark the board with the name of the system it is wired for. The space underneath the silkscreen text "FOR BEST RESULTS USE WITH:" is provided for this purpose.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ You will need to solder some jumper wires to configure the 13W3 adapter for the 
 Notes:
 1. The RS/6000 is wired for monitor ID 1010.
 2. The SGI wiring connections have not been tested but should work.
-3. Some video cards with Sun's old pinout lack Hsync and Vsync, so we connect Csync to the H pad (but see § Composite Sync).
-4. All video cards with Sun's DDC pinout lack Hsync, so we connect Csync to the H pad (but see § Composite Sync).
-5. Hdrive and Vdrive are not equivalent to Hsync and Vsync, so we connect Csync to the H pad (but see § Composite Sync).
+3. Some video cards with Sun's old pinout lack Hsync and Vsync, so we connect Csync to the H pad, but see [§ Composite Sync](#composite-sync-and-sync-on-green) for more details.
+4. All video cards with Sun's DDC pinout lack Hsync, so we connect Csync to the H pad, but see [§ Composite Sync](#composite-sync-and-sync-on-green) for more details.
+5. Hdrive and Vdrive are not equivalent to Hsync and Vsync, so we connect Csync to the H pad, but see [§ Composite Sync](#composite-sync-and-sync-on-green) for more details.
 6. Sense codes control the default resolution and refresh rate, unless DDC is supported and connected to your VGA monitor.
     * default sense code 000<sub>2</sub> is 1152x900@66
     * jump pins 3 and 9 to Gnd (101<sub>2</sub>) for 1280x1024@76

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Notes:
     * jump pins 3 and 9 to Gnd (101<sub>2</sub>) for 1280x1024@76
     * jump pin 8 to Gnd (010<sub>2</sub>) for 1024x768@60
     * for other sense codes, see [TurboGX/TurboGXplus Hardware Installation Guide](https://docs.oracle.com/cd/E19957-01/801-5399-10/801-5399-10.pdf), Table C-3
+    * not all sense codes are supported by all video cards, see the Sun [Frame Buffer FAQ](http://www.sunhelp.org/faq/FrameBuffer.html#5)
 4. The RS/6000 is wired for monitor ID 1010.
 5. The SGI wiring connections have not been tested but should work.
 

--- a/README.md
+++ b/README.md
@@ -17,22 +17,29 @@ Unless you need the composite sync separator, assembly is easy: just install J1 
 
 You will need to solder some jumper wires to configure the 13W3 adapter for the particular workstation you are using. Ground pads are located next to the pads that are marked with the pin number that they are connected to. Using the table below, connect the pads to ground, leave them floating, or jumper them to the H (horizontal sync) or V (vertical sync) pads.
 
-| 13W3 pin | Sun SPARCstation | RS/6000 [1] | SGI [2]     |
-|----------|--------------|-----------------|-------------|
-| 1        | n/c (ser rd) | Gnd (ID-2)      | n/c (mon3)  |
-| 2        | V            | n/c (ID-3)      | n/c (mon2)  |
-| 3        | n/c (sense0) | Gnd (self test) | n/c (Csync) |
-| 4        | Gnd          | Gnd             | H           |
-| 5        | n/c (Csync)  | H               | V           |
-| 6        | H            | Gnd (ID-0)      | n/c (mon1)  |
-| 7        | n/c (ser wr) | n/c (ID-1)      | n/c (mon2)  |
-| 8        | n/c (sense1) | n/c             | Gnd         |
-| 9        | n/c (sense2) | V               | Gnd         |
-| 10       | GND          | Gnd             | Gnd         |
+| 13W3 pin | Sun (old)          | Sun (DDC)        | RS/6000 [4]     | SGI [5]     |
+|----------|--------------------|------------------|-----------------|-------------|
+| 1        | n/c (serial read)  | n/c (DDC SCL)    | Gnd (ID-2)      | n/c (mon3)  |
+| 2        | n/c (Vsync) [1]    | n/c (DDC 5V)     | n/c (ID-3)      | n/c (mon2)  |
+| 3        | n/c (sense2) [3]   | n/c (sense2) [3] | Gnd (self test) | n/c (Csync) |
+| 4        | Gnd (for sense)    | Gnd (for DDC)    | Gnd             | H           |
+| 5        | H (Csync) [1]      | H (Csync) [2]    | H               | V           |
+| 6        | n/c (Hsync) [1]    | n/c (DDC SDA)    | Gnd (ID-0)      | n/c (mon1)  |
+| 7        | n/c (serial write) | n/c (Vsync) [2]  | n/c (ID-1)      | n/c (mon2)  |
+| 8        | n/c (sense1) [3]   | n/c (sense1) [3] | n/c             | Gnd         |
+| 9        | n/c (sense0) [3]   | n/c (sense0) [3] | V               | Gnd         |
+| 10       | Gnd (for sync)     | Gnd (for sync)   | Gnd             | Gnd         |
 
 Notes:
-1. The RS/6000 is wired for monitor ID 1010.
-2. The SGI wiring connections have not been tested but should work.
+1. Some video cards with Sun's old pinout lack Hsync and Vsync, so we connect Csync to the H pad (but see § Composite Sync).
+2. All video cards with Sun's DDC pinout lack Hsync, so we connect Csync to the H pad (but see § Composite Sync).
+3. Sense codes control the default resolution and refresh rate, unless DDC is supported and connected to your VGA monitor.
+    * default sense code 000<sub>2</sub> is 1152x900@66
+    * jump pins 3 and 9 to Gnd (101<sub>2</sub>) for 1280x1024@76
+    * jump pin 8 to Gnd (010<sub>2</sub>) for 1024x768@60
+    * for other sense codes, see [TurboGX/TurboGXplus Hardware Installation Guide](https://docs.oracle.com/cd/E19957-01/801-5399-10/801-5399-10.pdf), Table C-3
+4. The RS/6000 is wired for monitor ID 1010.
+5. The SGI wiring connections have not been tested but should work.
 
 Once you finish the wiring, it's a good idea to mark the board with the name of the system it is wired for. The space underneath the silkscreen text "FOR BEST RESULTS USE WITH:" is provided for this purpose.
 
@@ -40,7 +47,11 @@ If you figure out the wiring for a system not in this table, feel free to file a
 
 ### Composite Sync and Sync-On-Green
 
-Some workstations output composite sync or sync-on-green. Many modern LCD monitors already support sync-on-green, so you may not need to wire up any sync signals at all. If yours doesn't support it, or if the workstation outputs a separate composite sync signal, then you'll need to install these components:
+Some workstations output composite sync (Csync) or sync-on-green but not separate sync (Hsync and Vsync), such as the SPARCstation 5 with TurboGX.
+
+Many modern LCD monitors already support one or both of these. In the case of sync-on-green, you may not need to wire up any sync signals at all, whereas for composite sync, it may be enough to connect your Csync pin to the H pad.
+
+If yours doesn't support those, then you'll need to install these components:
 
 | Q | Designator | Description | Mouser part number |
 |---|------------|-------------|--------------------|
@@ -50,6 +61,6 @@ Some workstations output composite sync or sync-on-green. Many modern LCD monito
 | 1 | R2 | 10.0K ohm 1% 0603 resistor | |
 | 1 | U1 | LMH1980 sync separator | 926-LMH1980MM/NOPB |
 
-To separate sync-on-green, install a jumper wire across JP11. For composite sync, run a wire from the JP11 pad nearest R1 (marked CSYNC) to the appropriate pin on the 13W3 connector.
+To separate sync-on-green, install a jumper wire across JP11. For composite sync, run a wire from the JP11 pad nearest R1 (marked CSYNC) to the appropriate pin on the 13W3 connector. Be sure to disconnect your Csync pin from the H pad, if you connected it earlier.
 
 For this circuit to work, it needs 5V power, provided by J5 on the PCB (marked "5V GND"). If your workstation does not provide 5V on the 13W3 connector, you'll need to get it from somewhere else (keyboard port, external DC power supply, etc).


### PR DESCRIPTION
First of all, thanks for designing this adapter, it will make my Sun adventures a lot easier!

I built one for my SPARCstations 5 without the sync separator, since [the service manual](https://docs.oracle.com/cd/E19127-01/sparc5.ws/801-6396-11/801-6396-11.pdf) says the TurboGX (Table 12-1) has Hsync and Vsync (Table B-8), but it turns out they were wrong and I only had Csync. As a result, only one of the five VGA monitors I tested gave me a picture, and even that was barely usable:

1. Samsung SyncMaster 940N — waaaaay offscreen with a deep purple tint
2. Chimei CMV-938D — no signal
3. Panasonic PanaSync SM70 — no signal
4. Dell U2412M — no signal
5. Sony KDL40XBR — no signal

I did some research and found that VGA monitors often accept composite sync on the Hsync pin. Wiring pin 5 to the H pad, all five of the monitors I tested now detected a signal, and the first three now worked correctly at 1152x900@66.

I then found that the sense pins can be grounded to select a more compatible default mode like 1024x768@60 or 1280x1024@76. Now the U2412M worked correctly too, though I never found a working mode for the KDL40XBR.

This patch:

* adds a column for Sun’s newer DDC pinout, which never has Hsync
* adds a column for SGI’s newer DDC pinout, which seems to have Hsync and Vsync
* changes the advice for Sun workstations to try wiring Csync to the H pad, instead of Hsync and Vsync
* changes the advice for SGI’s older pinout to try wiring Csync to the H pad, instead of Hdrive and Vdrive
* documents how to switch to modes like 1024x768@60 or 1280x1024@76 by grounding the sense pins
* documents how to take advantage of a VGA monitor that supports composite sync

---

I made these changes based on a rabbit hole that left me with over 100 tabs open. In short, Sun has two incompatible pinouts for DB13W3, one of which only sometimes supports Hsync and one of which never does, and even their own docs are often contradictory or incorrect. Here are my sources for Sun:

* [Sun-4 Handbook](https://oldcomputers-ddns.org/public/pub/rechner/other_hardware/sun/sparc_4-330/sun-4x.pdf) says SBus CG3 has Hsync and Vsync, but SBus GX+ (CG6) has those pins grounded (page 144)
    * [Sun-3 Handbook](https://shrubbery.net/~heas/sun-feh-2_1/Systems/Sun3/FEH3.enter.html) ([Video Connector Pinouts](https://shrubbery.net/~heas/sun-feh-2_1/Systems/Sun3/MONITOR_02_Pinouts.html)) says the same, but the Sun-3 never had SBus
    * but [SPARCclassic/X/LX Service Manual](https://docs.oracle.com/cd/E19127-01/sparc.classic/801-2176-13/801-2176-13.pdf) (Table B-9) says the CG3 in those only has Csync
* [TurboGX/TurboGXplus Hardware Installation Guide](https://docs.oracle.com/cd/E19957-01/801-5399-10/801-5399-10.pdf) (Table C-2) says TGX/TGX+ has those pins n/c and reserved
    * but [SPARCstation 5 Service Manual](https://docs.oracle.com/cd/E19127-01/sparc5.ws/801-6396-11/801-6396-11.pdf) (Table B-8, Table 12-1) incorrectly says TGX has Hsync and Vsync
    * and so does [Ultra 1 Reference Manual](https://docs.oracle.com/cd/E19127-01/ultra1.ws/802-3816-10/802-3816-10.pdf) (Table 1-11) and [Service Manual](https://docs.oracle.com/cd/E19127-01/ultra1.ws/802-3819-10/802-3819-10.pdf) (Table 11-1)
* [Ultra 1 Creator Reference Manual](https://docs.oracle.com/cd/E19127-01/ultra1.ws/802-4147-11/802-4147-11.pdf) (Table 1-11) and [Service Manual](https://docs.oracle.com/cd/E19127-01/ultra1.ws/802-4148-11/802-4148-11.pdf) (Table 1-2) say FFB (UPA) has Hsync and Vsync
* [Ultra 60 Service Manual](https://www.g8wrb.co.uk/useful-stuff/Sun/U60/Ultra-60-reference-manual.pdf) (Table 1-16) and [Service Manual](https://docs.oracle.com/cd/E19127-01/ultra60.ws/805-1709-12/805-1709-12.pdf) (Table 11-1) says their UPA cards have Hsync and Vsync
* [Ultra 80 Service Manual](https://docs.oracle.com/cd/E19127-01/ultra80.ws/805-6618-11/805-6618-11.pdf) (Table B-17, Table 1-2) says Elite3D m6 (UPA) has Hsync and Vsync
* [Solaris Handbook for Sun Frame Buffers](https://docs.oracle.com/cd/E19455-01/806-4629-05/6jdmq4ikv/index.html) says Creator (UPA) and Creator 3D (UPA) check EDID before sense code
    * this implies the Creator (UPA) and Creator 3D (UPA) use Sun’s newer DDC pinout
* [Expert3D Installation Guide](https://docs.oracle.com/cd/E19125-01/exp.3d.acc/806-1859-10/806-1859-10.pdf) says Expert3D (PCI 66MHz) uses Sun’s newer DDC pinout
* Sun’s [Frame Buffer FAQ](http://www.sunhelp.org/faq/FrameBuffer.html#33) says their old pinout is unspecified, but Creator and Creator 3D and newer use DDC
* Birdsall’s [Sun Hardware Reference](http://www.alyon.org/InfosTechniques/informatique/SunHardwareReference/sunfaq.html) says that Hsync and Vsync are “considered obsolete” and may be n/c
* [Extron 13W3 adapter](https://www.extron.com/product/inputadapterkit) ([user guide](https://media.extron.com/public/download/files/userman/13W3-VGA_adapter_A.pdf)) says “older” Sun workstations lack Hsync and Vsync
    * [Higher Intellect Vintage Wiki](https://wiki.preterhuman.net/13W3) gets their pinouts from here, but is otherwise interesting
* some sources say the old pinout has serial read/write pins, others don’t, though I have no idea what they do
* for extra confusion, some sources number the sense pins backwards, like Sense &lt;0>, Sense &lt;1>, Sense &lt;2>

Here are my sources for SGI:


* [OCTANE Workstation Owner’s Guide](https://web.archive.org/web/20120602192024/http://www.sgistuff.net/hardware/systems/documents/007-3435-003-octane.pdf) (Table C-14, Table C-15) documents SGI’s old and DDC pinouts
    * the horizontal and vertical pins in the old pinout (Table C-14) are described as Horizontal Drive (Active High) and Vertical Drive (Active High), which suggests they [may not be compatible with Hsync and Vsync](https://netlib.org/graphics/video.signals)